### PR TITLE
Mount conda store in the dask scheduler

### DIFF
--- a/modules/kubernetes/services/meta/qhub/main.tf
+++ b/modules/kubernetes/services/meta/qhub/main.tf
@@ -109,8 +109,24 @@ module "kubernetes-dask-gateway" {
           image = var.dask-worker-image
 
           scheduler = {
+            extraContainerConfig = {
+              volumeMounts = [
+                {
+                  name      = "conda-store"
+                  mountPath = "/home/conda"
+                }
+              ]
+            }
             extraPodConfig = {
               affinity = local.affinity.worker-nodegroup
+              volumes = [
+                {
+                  name = "conda-store"
+                  persistentVolumeClaim = {
+                    claimName = var.conda-store-pvc
+                  }
+                }
+              ]
             }
           }
           worker = {


### PR DESCRIPTION
We have environment mismatch, when a set of libraries that are present in Client are either not present in Scheduler or have different versions there, this mounts conda-store to scheduler so that qhub can start the scheduler same as it starts the worker: https://github.com/Quansight/qhub-ops/pull/60