### PR TITLE
Return JupyterHub token as output from QHub module

### DIFF
--- a/modules/kubernetes/services/meta/qhub/output.tf
+++ b/modules/kubernetes/services/meta/qhub/output.tf
@@ -1,3 +1,8 @@
 output "depended_on" {
   value = "${null_resource.dependency_setter.id}-${timestamp()}"
 }
+
+output "jupyterhub_api_token" {
+  description = "API token to enable in jupyterhub server"
+  value       = module.kubernetes-dask-gateway.jupyterhub_api_token
+}


### PR DESCRIPTION
Qhub is the user facing module, it would nice to have the JupyterHub token as an output from the same, to be used as an input to other services, like say prefect.