### PR TITLE
Update main.tf

### DIFF
--- a/modules/kubernetes/ingress/main.tf
+++ b/modules/kubernetes/ingress/main.tf
@@ -29,7 +29,7 @@ resource "helm_release" "ingress" {
         controller = {
           affinity = local.affinity
           livenessProbe = {
-            timeoutSeconds = 10
+            timeoutSeconds = 20
           }
         }
 

--- a/modules/kubernetes/ingress/main.tf
+++ b/modules/kubernetes/ingress/main.tf
@@ -28,6 +28,9 @@ resource "helm_release" "ingress" {
       "nginx-ingress" = {
         controller = {
           affinity = local.affinity
+          livenessProbe = {
+            timeoutSeconds = 10
+          }
         }
 
         defaultBackend = {


### PR DESCRIPTION
Nginx was restarting because the timeout was too low, resulting in the following error:


│ Events:                                                                                                                                                                                                                                                                  ││   Type     Reason     Age                   From                                                       Message                                                                                                                                                           ││   ----     ------     ----                  ----                                                       -------                                                                                                                                                           ││   Warning  Unhealthy  13m (x23 over 113m)   kubelet, gke-qhub-datum-staging-dev-general-9d216648-4fgs  Readiness probe failed: Get http://10.0.1.5:10254/healthz: net/http: request canceled (Client.Timeout exceeded while awaiting headers)                            ││   Normal   Killing    13m (x4 over 89m)     kubelet, gke-qhub-datum-staging-dev-general-9d216648-4fgs  Container nginx-ingress-controller failed liveness probe, will be restarted                                                                                       ││   Warning  Unhealthy  12m (x14 over 89m)    kubelet, gke-qhub-datum-staging-dev-general-9d216648-4fgs  Readiness probe failed: HTTP probe failed with statuscode: 500                                                                                                    ││   Warning  Unhealthy  9m27s (x12 over 89m)  kubelet, gke-qhub-datum-staging-dev-general-9d216648-4fgs  Liveness probe failed: Get http://10.0.1.5:10254/healthz: net/http: request canceled (Client.Timeout exceeded while awaiting headers)                             │
