### PR TITLE
Fix kubernetes ingress endpoint expression

### DIFF
--- a/modules/digitalocean/registry/main.tf
+++ b/modules/digitalocean/registry/main.tf
@@ -1,3 +1,4 @@
 resource "digitalocean_container_registry" "registry" {
-  name = var.name
+  name                   = var.name
+  subscription_tier_slug = "starter"
 }

--- a/modules/kubernetes/ingress/outputs.tf
+++ b/modules/kubernetes/ingress/outputs.tf
@@ -1,7 +1,7 @@
 output "endpoint" {
   description = "Nginx ingress endpoint"
   # might need to use "hostname" for aws
-  value = data.kubernetes_service.ingress.load_balancer_ingress.0
+  value = data.kubernetes_service.ingress.status.0.load_balancer.0.ingress.0
 }
 
 output "depended_on" {


### PR DESCRIPTION
The kubernetes provider has few api changes and this one effects us immediately on all cloud providers. The documentation for the change is here: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/v2-upgrade-guide#changes-to-the-load_balancers_ingress-block-on-service-and-ingress

Partially Fixes https://github.com/Quansight/qhub-cloud/issues/261 other PR will be in [qhub-cloud](https://github.com/Quansight/qhub-cloud) repo in a bit.

Also adding `subscription_tier_slug` to the resource "digitalocean_container_registry" (since its required now)
https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/container_registry#example-usage