### PR TITLE
Fix requests argument syntax for kubernetes provider

### DIFF
--- a/modules/gcp/kubernetes/nvidia_installer.tf
+++ b/modules/gcp/kubernetes/nvidia_installer.tf
@@ -74,7 +74,7 @@ resource "kubernetes_daemonset" "nvidia_installer" {
           image = "gcr.io/cos-cloud/cos-gpu-installer@sha256:8d86a652759f80595cafed7d3dcde3dc53f57f9bc1e33b27bc3cfa7afea8d483"
           name  = "nvidia-driver-installer"
           resources {
-            requests {
+            requests = {
               cpu = 0.15
             }
           }


### PR DESCRIPTION
Fixes https://github.com/Quansight/qhub-cloud/issues/263

Ref: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/v2-upgrade-guide#changes-to-the-limits-and-requests-attributes-on-all-resources-that-support-a-podspec

> The limits and requests attributes on all resources that include a PodSpec, are now a map. This means that limits {} must be changed to limits = {}, and the same for requests. This change impacts the following resources: kubernetes_deployment, kubernetes_daemonset, kubernetes_stateful_set, kubernetes_pod, kubernetes_job, kubernetes_cron_job.

I have verified that nothing else is broken, by successfully deploying on GCP.