### PR TITLE
Handle the case of empty ingress

### DIFF
--- a/modules/kubernetes/ingress/outputs.tf
+++ b/modules/kubernetes/ingress/outputs.tf
@@ -1,4 +1,9 @@
+locals {
+  ingress = kubernetes_service.main.status.0.load_balancer.0.ingress
+}
+
 output "endpoint" {
   description = "traefik load balancer endpoint"
-  value       = kubernetes_service.main.status.0.load_balancer.0.ingress.0
+  //  handles the case when ingress is empty list
+  value = length(local.ingress) == 0 ? null : local.ingress.0
 }


### PR DESCRIPTION
This is when the deployment fails for some reason and ingress doesn't exists, then terraform is in a weird state due to the output expression havinng a runtime error and it throws following error:

```
Error: Invalid index

  on .terraform/modules/kubernetes-ingress/modules/kubernetes/ingress/outputs.tf line 3, in output "endpoint":
   3:   value       = kubernetes_service.main.status.0.load_balancer.0.ingress.0
    |----------------
    | kubernetes_service.main.status[0].load_balancer[0].ingress is empty list of object

The given key does not identify an element in this collection value.
```

This PR fixes the above issue.