### PR TITLE
Remove dependency hack prior to Terraform 0.13 release

### DIFF
--- a/modules/aws/kubernetes/main.tf
+++ b/modules/aws/kubernetes/main.tf
@@ -1,9 +1,3 @@
-resource "null_resource" "dependency_getter" {
-  triggers = {
-    my_dependencies = join(",", var.dependencies)
-  }
-}
-
 resource "aws_eks_cluster" "main" {
   name     = var.name
   role_arn = aws_iam_role.cluster.arn
@@ -15,7 +9,6 @@ resource "aws_eks_cluster" "main" {
 
   depends_on = [
     aws_iam_role_policy_attachment.cluster-policy,
-    null_resource.dependency_getter
   ]
 
   tags = merge({ Name = var.name }, var.tags)
@@ -43,7 +36,6 @@ resource "aws_eks_node_group" "main" {
   # properly delete EC2 Instances and Elastic Network Interfaces.
   depends_on = [
     aws_iam_role_policy_attachment.node-group-policy,
-    null_resource.dependency_getter
   ]
 
   tags = merge({
@@ -53,11 +45,4 @@ resource "aws_eks_node_group" "main" {
 
 data "aws_eks_cluster_auth" "main" {
   name = aws_eks_cluster.main.name
-}
-
-resource "null_resource" "dependency_setter" {
-  depends_on = [
-    aws_eks_node_group.main
-    # List resource(s) that will be constructed last within the module.
-  ]
 }

--- a/modules/aws/kubernetes/outputs.tf
+++ b/modules/aws/kubernetes/outputs.tf
@@ -11,7 +11,3 @@ output "credentials" {
 output "node_groups_arn" {
   value = aws_eks_node_group.main[*].arn
 }
-
-output "depended_on" {
-  value = "${null_resource.dependency_setter.id}-${timestamp()}"
-}

--- a/modules/aws/kubernetes/variables.tf
+++ b/modules/aws/kubernetes/variables.tf
@@ -47,9 +47,3 @@ variable "node_group_instance_type" {
   type        = string
   default     = "m5.large"
 }
-
-variable "dependencies" {
-  description = "A list of module dependencies to be injected in the module"
-  type        = list(any)
-  default     = []
-}

--- a/modules/aws/network/main.tf
+++ b/modules/aws/network/main.tf
@@ -1,9 +1,3 @@
-resource "null_resource" "dependency_getter" {
-  triggers = {
-    my_dependencies = join(",", var.dependencies)
-  }
-}
-
 resource "aws_vpc" "main" {
   cidr_block = var.vpc_cidr_block
 
@@ -12,7 +6,6 @@ resource "aws_vpc" "main" {
   enable_classiclink   = false
 
   tags       = merge({ Name = var.name }, var.tags, var.vpc_tags)
-  depends_on = [null_resource.dependency_getter]
 }
 
 resource "aws_subnet" "main" {
@@ -24,14 +17,12 @@ resource "aws_subnet" "main" {
   map_public_ip_on_launch = true
 
   tags       = merge({ Name = "${var.name}-subnet-${count.index}" }, var.tags, var.subnet_tags)
-  depends_on = [null_resource.dependency_getter]
 }
 
 resource "aws_internet_gateway" "main" {
   vpc_id = aws_vpc.main.id
 
   tags       = merge({ Name = var.name }, var.tags)
-  depends_on = [null_resource.dependency_getter]
 }
 
 resource "aws_route_table" "main" {
@@ -43,7 +34,6 @@ resource "aws_route_table" "main" {
   }
 
   tags       = merge({ Name = var.name }, var.tags)
-  depends_on = [null_resource.dependency_getter]
 }
 
 resource "aws_route_table_association" "main" {
@@ -51,7 +41,6 @@ resource "aws_route_table_association" "main" {
 
   subnet_id      = aws_subnet.main[count.index].id
   route_table_id = aws_route_table.main.id
-  depends_on     = [null_resource.dependency_getter]
 }
 
 resource "aws_security_group" "main" {
@@ -75,17 +64,4 @@ resource "aws_security_group" "main" {
   }
 
   tags       = merge({ Name = var.name }, var.tags, var.security_group_tags)
-  depends_on = [null_resource.dependency_getter]
-}
-
-resource "null_resource" "dependency_setter" {
-  depends_on = [
-    aws_vpc.main,
-    aws_subnet.main,
-    aws_internet_gateway.main,
-    aws_route_table.main,
-    aws_route_table_association.main,
-    aws_security_group.main,
-    # List resource(s) that will be constructed last within the module.
-  ]
 }

--- a/modules/aws/network/main.tf
+++ b/modules/aws/network/main.tf
@@ -5,7 +5,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
   enable_classiclink   = false
 
-  tags       = merge({ Name = var.name }, var.tags, var.vpc_tags)
+  tags = merge({ Name = var.name }, var.tags, var.vpc_tags)
 }
 
 resource "aws_subnet" "main" {
@@ -16,13 +16,13 @@ resource "aws_subnet" "main" {
   vpc_id                  = aws_vpc.main.id
   map_public_ip_on_launch = true
 
-  tags       = merge({ Name = "${var.name}-subnet-${count.index}" }, var.tags, var.subnet_tags)
+  tags = merge({ Name = "${var.name}-subnet-${count.index}" }, var.tags, var.subnet_tags)
 }
 
 resource "aws_internet_gateway" "main" {
   vpc_id = aws_vpc.main.id
 
-  tags       = merge({ Name = var.name }, var.tags)
+  tags = merge({ Name = var.name }, var.tags)
 }
 
 resource "aws_route_table" "main" {
@@ -33,7 +33,7 @@ resource "aws_route_table" "main" {
     gateway_id = aws_internet_gateway.main.id
   }
 
-  tags       = merge({ Name = var.name }, var.tags)
+  tags = merge({ Name = var.name }, var.tags)
 }
 
 resource "aws_route_table_association" "main" {
@@ -63,5 +63,5 @@ resource "aws_security_group" "main" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags       = merge({ Name = var.name }, var.tags, var.security_group_tags)
+  tags = merge({ Name = var.name }, var.tags, var.security_group_tags)
 }

--- a/modules/aws/network/outputs.tf
+++ b/modules/aws/network/outputs.tf
@@ -12,7 +12,3 @@ output "vpc_id" {
   description = "AWS VPC id"
   value       = aws_vpc.main.id
 }
-
-output "depended_on" {
-  value = "${null_resource.dependency_setter.id}-${timestamp()}"
-}

--- a/modules/aws/network/variables.tf
+++ b/modules/aws/network/variables.tf
@@ -36,9 +36,3 @@ variable "vpc_cidr_block" {
   description = "VPC cidr for subnets to inside of"
   type        = string
 }
-
-variable "dependencies" {
-  description = "A list of module dependencies to be injected in the module"
-  type        = list(any)
-  default     = []
-}

--- a/modules/kubernetes/initialization/main.tf
+++ b/modules/kubernetes/initialization/main.tf
@@ -18,5 +18,5 @@ resource "kubernetes_secret" "main" {
 
   data = var.secrets[count.index].data
 
-  type       = "Opaque"
+  type = "Opaque"
 }

--- a/modules/kubernetes/initialization/main.tf
+++ b/modules/kubernetes/initialization/main.tf
@@ -1,16 +1,9 @@
-resource "null_resource" "dependency_getter" {
-  triggers = {
-    my_dependencies = join(",", var.dependencies)
-  }
-}
-
 resource "kubernetes_namespace" "main" {
   metadata {
     labels = merge({}, var.labels)
 
     name = var.namespace
   }
-  depends_on = [null_resource.dependency_getter]
 }
 
 
@@ -26,13 +19,4 @@ resource "kubernetes_secret" "main" {
   data = var.secrets[count.index].data
 
   type       = "Opaque"
-  depends_on = [null_resource.dependency_getter]
-}
-
-resource "null_resource" "dependency_setter" {
-  depends_on = [
-    kubernetes_namespace.main,
-    kubernetes_secret.main
-    # List resource(s) that will be constructed last within the module.
-  ]
 }

--- a/modules/kubernetes/initialization/outputs.tf
+++ b/modules/kubernetes/initialization/outputs.tf
@@ -1,3 +1,0 @@
-output "depended_on" {
-  value = "${null_resource.dependency_setter.id}-${timestamp()}"
-}

--- a/modules/kubernetes/initialization/variables.tf
+++ b/modules/kubernetes/initialization/variables.tf
@@ -17,9 +17,3 @@ variable "secrets" {
   }))
   default = []
 }
-
-variable "dependencies" {
-  description = "A list of module dependencies to be injected in the module"
-  type        = list(any)
-  default     = []
-}

--- a/modules/kubernetes/nfs-mount/main.tf
+++ b/modules/kubernetes/nfs-mount/main.tf
@@ -1,16 +1,9 @@
-resource "null_resource" "dependency_getter" {
-  triggers = {
-    my_dependencies = join(",", var.dependencies)
-  }
-}
-
 resource "kubernetes_storage_class" "main" {
   metadata {
     name = "${var.name}-${var.namespace}-share"
   }
 
   storage_provisioner = "kubernetes.io/fake-nfs"
-  depends_on          = [null_resource.dependency_getter]
 }
 
 
@@ -31,7 +24,6 @@ resource "kubernetes_persistent_volume" "main" {
       }
     }
   }
-  depends_on = [null_resource.dependency_getter]
 }
 
 
@@ -50,11 +42,4 @@ resource "kubernetes_persistent_volume_claim" "main" {
       }
     }
   }
-  depends_on = [null_resource.dependency_getter]
-}
-
-resource "null_resource" "dependency_setter" {
-  depends_on = [
-    # List resource(s) that will be constructed last within the module.
-  ]
 }

--- a/modules/kubernetes/nfs-mount/outputs.tf
+++ b/modules/kubernetes/nfs-mount/outputs.tf
@@ -5,7 +5,3 @@ output "persistent_volume_claim" {
     namespace = var.namespace
   }
 }
-
-output "depended_on" {
-  value = "${null_resource.dependency_setter.id}-${timestamp()}"
-}

--- a/modules/kubernetes/nfs-mount/variables.tf
+++ b/modules/kubernetes/nfs-mount/variables.tf
@@ -18,9 +18,3 @@ variable "nfs_endpoint" {
   description = "Endpoint of nfs server"
   type        = string
 }
-
-variable "dependencies" {
-  description = "A list of module dependencies to be injected in the module"
-  type        = list(any)
-  default     = []
-}

--- a/modules/kubernetes/services/cluster-autoscaler/main.tf
+++ b/modules/kubernetes/services/cluster-autoscaler/main.tf
@@ -1,9 +1,3 @@
-resource "null_resource" "dependency_getter" {
-  triggers = {
-    my_dependencies = join(",", var.dependencies)
-  }
-}
-
 data "helm_repository" "autoscaler" {
   name = "stable"
   url  = "https://charts.helm.sh/stable"
@@ -32,13 +26,4 @@ resource "helm_release" "autoscaler" {
       }
     })
   ], var.overrides)
-  depends_on = [
-    null_resource.dependency_getter
-  ]
-}
-
-resource "null_resource" "dependency_setter" {
-  depends_on = [
-    # List resource(s) that will be constructed last within the module.
-  ]
 }

--- a/modules/kubernetes/services/cluster-autoscaler/output.tf
+++ b/modules/kubernetes/services/cluster-autoscaler/output.tf
@@ -1,3 +1,0 @@
-output "depended_on" {
-  value = "${null_resource.dependency_setter.id}-${timestamp()}"
-}

--- a/modules/kubernetes/services/cluster-autoscaler/variables.tf
+++ b/modules/kubernetes/services/cluster-autoscaler/variables.tf
@@ -18,9 +18,3 @@ variable "overrides" {
   type        = list(string)
   default     = []
 }
-
-variable "dependencies" {
-  description = "A list of module dependencies to be injected in the module"
-  type        = list(any)
-  default     = []
-}

--- a/modules/kubernetes/services/dask-gateway/main.tf
+++ b/modules/kubernetes/services/dask-gateway/main.tf
@@ -1,9 +1,3 @@
-resource "null_resource" "dependency_getter" {
-  triggers = {
-    my_dependencies = join(",", var.dependencies)
-  }
-}
-
 data "helm_repository" "dask-gateway" {
   name = "dask-gateway"
   url  = "https://dask.org/dask-gateway-helm-repo/"
@@ -50,13 +44,4 @@ resource "helm_release" "dask-gateway" {
     name  = "gateway.auth.jupyterhub.apiToken"
     value = random_password.jupyterhub_api_token.result
   }
-  depends_on = [
-    null_resource.dependency_getter
-  ]
-}
-
-resource "null_resource" "dependency_setter" {
-  depends_on = [
-    # List resource(s) that will be constructed last within the module.
-  ]
 }

--- a/modules/kubernetes/services/dask-gateway/outputs.tf
+++ b/modules/kubernetes/services/dask-gateway/outputs.tf
@@ -15,7 +15,3 @@ output "config" {
     }
   }
 }
-
-output "depended_on" {
-  value = "${null_resource.dependency_setter.id}-${timestamp()}"
-}

--- a/modules/kubernetes/services/dask-gateway/variables.tf
+++ b/modules/kubernetes/services/dask-gateway/variables.tf
@@ -19,9 +19,3 @@ variable "overrides" {
   type        = list(string)
   default     = []
 }
-
-variable "dependencies" {
-  description = "A list of module dependencies to be injected in the module"
-  type        = list(any)
-  default     = []
-}

--- a/modules/kubernetes/services/jupyterhub/main.tf
+++ b/modules/kubernetes/services/jupyterhub/main.tf
@@ -1,9 +1,3 @@
-resource "null_resource" "dependency_getter" {
-  triggers = {
-    my_dependencies = join(",", var.dependencies)
-  }
-}
-
 data "helm_repository" "jupyterhub" {
   name = "jupyterhub"
   url  = "https://jupyterhub.github.io/helm-chart/"
@@ -30,15 +24,4 @@ resource "helm_release" "jupyterhub" {
     name  = "proxy.secretToken"
     value = random_password.proxy_secret_token.result
   }
-
-  depends_on = [
-    null_resource.dependency_getter
-  ]
-}
-
-resource "null_resource" "dependency_setter" {
-  depends_on = [
-    helm_release.jupyterhub
-    # List resource(s) that will be constructed last within the module.
-  ]
 }

--- a/modules/kubernetes/services/jupyterhub/output.tf
+++ b/modules/kubernetes/services/jupyterhub/output.tf
@@ -1,3 +1,0 @@
-output "depended_on" {
-  value = "${null_resource.dependency_setter.id}-${timestamp()}"
-}

--- a/modules/kubernetes/services/jupyterhub/variables.tf
+++ b/modules/kubernetes/services/jupyterhub/variables.tf
@@ -8,9 +8,3 @@ variable "overrides" {
   type        = list(string)
   default     = []
 }
-
-variable "dependencies" {
-  description = "A list of module dependencies to be injected in the module"
-  type        = list(any)
-  default     = []
-}

--- a/modules/kubernetes/services/kubessh/main.tf
+++ b/modules/kubernetes/services/kubessh/main.tf
@@ -3,12 +3,6 @@ resource "tls_private_key" "kubessh_private_key" {
   rsa_bits  = 4096
 }
 
-resource "null_resource" "dependency_getter" {
-  triggers = {
-    my_dependencies = join(",", var.dependencies)
-  }
-}
-
 data "helm_repository" "kubessh" {
   name = "kubessh"
   url  = "https://chart.kubessh.org"
@@ -33,14 +27,4 @@ resource "helm_release" "kubessh" {
       }
     }),
   ], var.overrides)
-
-  depends_on = [
-    null_resource.dependency_getter
-  ]
-}
-
-resource "null_resource" "dependency_setter" {
-  depends_on = [
-    # List resource(s) that will be constructed last within the module.
-  ]
 }

--- a/modules/kubernetes/services/kubessh/outputs.tf
+++ b/modules/kubernetes/services/kubessh/outputs.tf
@@ -11,7 +11,3 @@ output "service" {
     namespace = var.namespace
   }
 }
-
-output "depended_on" {
-  value = "${null_resource.dependency_setter.id}-${timestamp()}"
-}

--- a/modules/kubernetes/services/kubessh/variables.tf
+++ b/modules/kubernetes/services/kubessh/variables.tf
@@ -14,9 +14,3 @@ variable "overrides" {
   type        = list(string)
   default     = []
 }
-
-variable "dependencies" {
-  description = "A list of module dependencies to be injected in kubessh"
-  type        = list(any)
-  default     = []
-}

--- a/modules/kubernetes/services/meta/qhub/main.tf
+++ b/modules/kubernetes/services/meta/qhub/main.tf
@@ -157,9 +157,10 @@ module "kubernetes-dask-gateway" {
     })
   ])
 
-  depends_on = [
-    module.kubernetes-jupyterhub
-  ]
+  ## Causes cyclic dependency need to rewrite module
+  # depends_on = [
+  #   module.kubernetes-jupyterhub
+  # ]
 }
 
 resource "kubernetes_config_map" "dask-etc" {

--- a/modules/kubernetes/services/meta/qhub/output.tf
+++ b/modules/kubernetes/services/meta/qhub/output.tf
@@ -1,7 +1,3 @@
-output "depended_on" {
-  value = "${null_resource.dependency_setter.id}-${timestamp()}"
-}
-
 output "jupyterhub_api_token" {
   description = "API token to enable in jupyterhub server"
   value       = module.kubernetes-dask-gateway.jupyterhub_api_token

--- a/modules/kubernetes/services/meta/qhub/variables.tf
+++ b/modules/kubernetes/services/meta/qhub/variables.tf
@@ -81,9 +81,3 @@ variable "dask-gateway-overrides" {
   type        = list(string)
   default     = []
 }
-
-variable "dependencies" {
-  description = "A list of module dependencies to be injected in the module"
-  type        = list(any)
-  default     = []
-}

--- a/modules/kubernetes/services/prefect/main.tf
+++ b/modules/kubernetes/services/prefect/main.tf
@@ -1,9 +1,3 @@
-resource "null_resource" "dependency_getter" {
-  triggers = {
-    my_dependencies = join(",", var.dependencies)
-  }
-}
-
 resource "helm_release" "prefect" {
   name      = "prefect"
   namespace = var.namespace
@@ -18,15 +12,4 @@ resource "helm_release" "prefect" {
     name  = "jupyterHubToken"
     value = var.jupyterhub_api_token
   }
-
-  depends_on = [
-    null_resource.dependency_getter
-  ]
 }
-
-resource "null_resource" "dependency_setter" {
-  depends_on = [
-    # List resource(s) that will be constructed last within the module.
-  ]
-}
-

--- a/modules/kubernetes/services/prefect/output.tf
+++ b/modules/kubernetes/services/prefect/output.tf
@@ -1,3 +1,0 @@
-output "depended_on" {
-  value = "${null_resource.dependency_setter.id}-${timestamp()}"
-}

--- a/modules/kubernetes/services/prefect/variables.tf
+++ b/modules/kubernetes/services/prefect/variables.tf
@@ -12,9 +12,3 @@ variable "prefect_token" {
   type    = string
   default = ""
 }
-
-variable "dependencies" {
-  description = "A list of module dependencies to be injected in the module"
-  type        = list(any)
-  default     = []
-}


### PR DESCRIPTION
Since `depends_on` was added to Terraform 0.13 this code is no longer required.