### PR TITLE
AWS availability_zones ignore changes

### DIFF
--- a/modules/aws/network/main.tf
+++ b/modules/aws/network/main.tf
@@ -19,9 +19,9 @@ resource "aws_subnet" "main" {
   tags = merge({ Name = "${var.name}-subnet-${count.index}" }, var.tags, var.subnet_tags)
 
   lifecycle {
-     ignore_changes = [
-       availability_zone
-     ]
+    ignore_changes = [
+      availability_zone
+    ]
   }
 }
 

--- a/modules/aws/network/main.tf
+++ b/modules/aws/network/main.tf
@@ -17,6 +17,12 @@ resource "aws_subnet" "main" {
   map_public_ip_on_launch = true
 
   tags = merge({ Name = "${var.name}-subnet-${count.index}" }, var.tags, var.subnet_tags)
+
+  lifecycle {
+     ignore_changes = [
+       availability_zone
+     ]
+  }
 }
 
 resource "aws_internet_gateway" "main" {


### PR DESCRIPTION
A recent PR to QHub removed the need for availability_zones to be specified in qhub-config.yaml. If not provided, the first two availability zones returned by the aws_availability_zones data source are used for the network.

That is fine, but could cause problems if the availability zones list is changed by AWS, or if the user suddenly adds availability_zones to the qhub-config.yaml.

This PR to qhub-terraform-modules adds `ignore_changes` lifecycle metadata so that changes to the availability zones passed through will not cause updates to be issued.

I think if we do this we might as well completely remove the ability to specify availability_zones in qhub-config.yaml. It seems unlikely that a user will have a preference (beyond setting the region) when first deploying the qhub.
